### PR TITLE
Add manual emoji-reaction trigger to football relocator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,26 @@
 import 'dotenv/config'
 
-import { Client, GatewayIntentBits, Message, Interaction } from 'discord.js'
+import {
+    Client,
+    GatewayIntentBits,
+    Partials,
+    Message,
+    Interaction,
+} from 'discord.js'
 import { newMessageInChannel } from './handlers/new-message.handler'
 import { newInteractionHandler } from './handlers/new-interaction.handler'
+import { maybeRelocateFootballByReaction } from './services/message-relocator.service'
 
 const client = new Client({
     intents: [
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
         GatewayIntentBits.MessageContent,
+        GatewayIntentBits.GuildMessageReactions,
     ],
+    // Reactions usually land on messages posted before the bot started (not
+    // cached), so we must opt into partials to receive those events.
+    partials: [Partials.Message, Partials.Reaction],
 })
 client.once('clientReady', () => {
     console.log(`✅ Logged in as ${client.user?.tag}`)
@@ -20,6 +31,9 @@ client.on('messageCreate', (message: Message) => {
 })
 client.on('interactionCreate', (interaction: Interaction) => {
     newInteractionHandler(interaction)
+})
+client.on('messageReactionAdd', (reaction) => {
+    maybeRelocateFootballByReaction(reaction)
 })
 
 client.login(process.env.TOKEN)

--- a/src/services/message-relocator.service.ts
+++ b/src/services/message-relocator.service.ts
@@ -1,11 +1,13 @@
 import {
     Message,
+    MessageReaction,
+    PartialMessageReaction,
     Webhook,
     WebhookType,
     TextChannel,
     NewsChannel,
 } from 'discord.js'
-import { isFootballMessage } from './football-detector.service'
+import { isFootballMessage, geminiIsFootball } from './football-detector.service'
 
 const WEBHOOK_NAME = 'shitpost-relocator'
 
@@ -79,6 +81,20 @@ export const relocateMessage = async (
 }
 
 /**
+ * Shared guard for both relocator entry points: the message is from the watched
+ * user, isn't already in the target channel, and has text to forward. Kept in
+ * one place so the two callers can't drift apart.
+ */
+const isRelocatableMessage = (
+    message: Message,
+    watchedUserId: string,
+    targetChannelId: string
+): boolean =>
+    message.author.id === watchedUserId &&
+    message.channelId !== targetChannelId &&
+    message.content.trim().length > 0
+
+/**
  * Feature entry point for the message handler: if this message is a football
  * post from the watched user (and the feature is configured), relocate it.
  * Returns true when the message was handled so the caller can stop processing.
@@ -94,9 +110,7 @@ export const maybeRelocateFootballMessage = async (
     if (
         !watchedUserId ||
         !targetChannelId ||
-        message.author.id !== watchedUserId ||
-        message.channelId === targetChannelId ||
-        message.content.trim().length === 0
+        !isRelocatableMessage(message, watchedUserId, targetChannelId)
     ) {
         return false
     }
@@ -105,4 +119,56 @@ export const maybeRelocateFootballMessage = async (
 
     await relocateMessage(message, targetChannelId)
     return true
+}
+
+/**
+ * Manual fallback for posts the auto-detector missed: when 2 users react with
+ * the configured trigger emoji to one of the watched user's messages, force the
+ * Gemini analysis (skipping the keyword shortcut, which already let this message
+ * through on create) and relocate it if Gemini agrees it's football.
+ *
+ * Returns true when the message was relocated. Best-effort: any failure is
+ * logged and leaves the original in place.
+ */
+export const maybeRelocateFootballByReaction = async (
+    reactionInput: MessageReaction | PartialMessageReaction
+): Promise<boolean> => {
+    const watchedUserId = process.env.SHITPOST_USER_ID
+    const targetChannelId = process.env.SHITPOST_TARGET_CHANNEL_ID
+    const triggerEmoji = process.env.SHITPOST_TRIGGER_EMOJI // custom emoji ID
+    if (!watchedUserId || !targetChannelId || !triggerEmoji) return false
+
+    // Cheapest check first, against the partial: the emoji is always populated,
+    // so we reject the overwhelming majority of reactions (wrong emoji) before
+    // paying for any network fetch. Match by ID (custom emoji) or name (unicode).
+    if (
+        reactionInput.emoji.id !== triggerEmoji &&
+        reactionInput.emoji.name !== triggerEmoji
+    )
+        return false
+
+    try {
+        // Resolve partials (reactions on uncached/old messages arrive partial).
+        const reaction = reactionInput.partial
+            ? await reactionInput.fetch()
+            : reactionInput
+
+        if (reaction.count < 2) return false
+
+        const message = reaction.message.partial
+            ? await reaction.message.fetch()
+            : reaction.message
+
+        if (!isRelocatableMessage(message, watchedUserId, targetChannelId))
+            return false
+
+        // Force the LLM — the keyword path already let this through on create.
+        if (!(await geminiIsFootball(message.content))) return false
+
+        await relocateMessage(message, targetChannelId)
+        return true
+    } catch (e) {
+        console.log('[relocator] reaction trigger failed:', e)
+        return false
+    }
 }


### PR DESCRIPTION
## Context

The auto-relocator (`maybeRelocateFootballMessage`, on every `messageCreate`) only runs the **keyword pre-check** on send — the LLM is reached only for ambiguous keyword hits. The watched user can bypass it entirely by posting football content with no known keywords: the pre-check returns `no`, Gemini never runs, and the message stays put.

This adds a **manual fallback**: when **2 users react** to the watched user's message with a configured trigger emoji, we **force** the Gemini analysis and relocate the message if it's football-related.

## Changes

**`src/index.ts`**
- Enable the `GuildMessageReactions` intent and `Partials.Message` / `Partials.Reaction` (reactions usually land on messages posted before the bot started, which aren't cached — without partials the event never fires for them).
- Add a `messageReactionAdd` listener delegating to the new handler.

**`src/services/message-relocator.service.ts`**
- New `maybeRelocateFootballByReaction(reaction)`, a sibling of `maybeRelocateFootballMessage`:
  - **Cheap emoji match runs first**, against the partial, so the vast majority of reactions (wrong emoji) are rejected before any network fetch — `messageReactionAdd` is a hot path.
  - Gated on `reaction.count >= 2` and the message being from `SHITPOST_USER_ID`, not already in the target channel, and non-empty.
  - Calls `geminiIsFootball` **directly** (forces the LLM, unlike the keyword-first on-send path), then reuses the existing `relocateMessage`.
- Extracted a shared `isRelocatableMessage` guard so the two entry points can't drift.

## Behavior summary

Reaction added → config set? → right emoji? → ≥ 2 reactions? → watched user's message? → Gemini says football? → relocate via webhook + delete original. Any earlier check failing is a no-op.

## Required config

Add a new env var (custom server emoji **ID**, not `:name:`):

```
SHITPOST_TRIGGER_EMOJI=<custom emoji id>
```

> Heads-up: `.env.example` isn't updated in this PR (the file is outside my edit permissions) — please add the line there too.

## Verification

1. `npm run build` — passes clean (tsc + esbuild).
2. Set `SHITPOST_TRIGGER_EMOJI`, start the bot.
3. As the watched user, post football content with no strong keyword → confirm it is **not** auto-relocated on send.
4. Have 2 users react with the trigger emoji → confirm it's reposted in `SHITPOST_TARGET_CHANNEL_ID` (author name/avatar via webhook) and the original is deleted.
5. Negatives: non-football message stays; non-watched user's message stays; a single reaction does nothing; wrong emoji does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)