### PR TITLE
Justin trabaja reaction

### DIFF
--- a/src/components/geminiClient.ts
+++ b/src/components/geminiClient.ts
@@ -1,0 +1,11 @@
+import { GoogleGenAI } from '@google/genai'
+
+let genaiClient: GoogleGenAI | null = null
+export const getClient = (): GoogleGenAI => {
+    if (!genaiClient) {
+        genaiClient = new GoogleGenAI({
+            apiKey: process.env.GEMINI_API_KEY ?? '',
+        })
+    }
+    return genaiClient
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,10 @@ import {
 } from 'discord.js'
 import { newMessageInChannel } from './handlers/new-message.handler'
 import { newInteractionHandler } from './handlers/new-interaction.handler'
-import { maybeRelocateFootballByReaction } from './services/message-relocator.service'
+import {
+    maybeRelocateFootballByReaction,
+    maybeRespondFatigueByReaction,
+} from './services/message-relocator.service'
 
 const client = new Client({
     intents: [
@@ -33,7 +36,8 @@ client.on('interactionCreate', (interaction: Interaction) => {
     newInteractionHandler(interaction)
 })
 client.on('messageReactionAdd', (reaction) => {
-    maybeRelocateFootballByReaction(reaction)
+    void maybeRelocateFootballByReaction(reaction)
+    void maybeRespondFatigueByReaction(reaction)
 })
 
 client.login(process.env.TOKEN)

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ const client = new Client({
     partials: [Partials.Message, Partials.Reaction],
 })
 client.once('clientReady', () => {
-    console.log(`✅ Logged in as ${client.user?.tag}`)
+    console.log(`✅ Logged in as ${client.user?.tag} !`)
 })
 
 client.on('messageCreate', (message: Message) => {

--- a/src/scripts/analyze-user-history.ts
+++ b/src/scripts/analyze-user-history.ts
@@ -38,7 +38,7 @@ const userId = process.env.SHITPOST_USER_ID
 const channelId =
     process.env.ANALYZE_CHANNEL_ID ?? process.env.SHITPOST_TARGET_CHANNEL_ID
 const maxMessages = Number(process.env.ANALYZE_MAX_MESSAGES ?? '1000')
-const model = process.env.GEMINI_MODEL ?? 'gemini-flash-latest'
+const model = process.env.GEMINI_MODEL ?? ''
 
 async function main() {
     console.log('=== Football keyword bootstrap ===')

--- a/src/services/football-detector.service.ts
+++ b/src/services/football-detector.service.ts
@@ -129,7 +129,7 @@ export const keywordHasFootball = (content: string): 'yes' | 'no' | 'maybe' => {
     if (AMBIGUOUS_MATCHERS.some((m) => matches(text, m))) return 'maybe'
     return 'no'
 }
-const GEMINI_MODEL = process.env.GEMINI_MODEL ?? 'gemini-flash-latest'
+const GEMINI_MODEL = process.env.GEMINI_MODEL ?? ''
 /**
  * Ask Gemini Flash whether a (Spanish) message is about football/soccer.
  * Fails open: any error returns false so we never delete a message we're

--- a/src/services/football-detector.service.ts
+++ b/src/services/football-detector.service.ts
@@ -157,6 +157,7 @@ export const geminiIsFootball = async (content: string): Promise<boolean> => {
         })
 
         const answer = (response.text ?? '').trim().toLowerCase()
+        console.log(`geminiIsFootball answer ${answer}`)
         return (
             answer.startsWith('si') ||
             answer.startsWith('sí') ||

--- a/src/services/football-detector.service.ts
+++ b/src/services/football-detector.service.ts
@@ -1,5 +1,5 @@
-import { GoogleGenAI } from '@google/genai'
 import { loadLearnedKeywords } from './learned-keywords.service'
+import { getClient } from '../components/geminiClient'
 
 // Strong football/soccer signals. The watched user posts in Spanish, so the
 // list is Spanish-first with a few code-switched English terms mixed in.
@@ -129,19 +129,7 @@ export const keywordHasFootball = (content: string): 'yes' | 'no' | 'maybe' => {
     if (AMBIGUOUS_MATCHERS.some((m) => matches(text, m))) return 'maybe'
     return 'no'
 }
-
 const GEMINI_MODEL = process.env.GEMINI_MODEL ?? 'gemini-flash-latest'
-
-let genaiClient: GoogleGenAI | null = null
-const getClient = (): GoogleGenAI => {
-    if (!genaiClient) {
-        genaiClient = new GoogleGenAI({
-            apiKey: process.env.GEMINI_API_KEY ?? '',
-        })
-    }
-    return genaiClient
-}
-
 /**
  * Ask Gemini Flash whether a (Spanish) message is about football/soccer.
  * Fails open: any error returns false so we never delete a message we're

--- a/src/services/message-relocator.service.ts
+++ b/src/services/message-relocator.service.ts
@@ -167,7 +167,7 @@ export const maybeRespondFatigueByReaction = async (
 
         if (!(await geminiIsWorkRelated(message.content))) return false
 
-        await message.react(responseEmoji)
+        await message.reply(`Si Justin <:custom_name:${responseEmoji}>`)
         return true
     } catch (e) {
         console.log('[relocator] fatigue reaction failed:', e)

--- a/src/services/message-relocator.service.ts
+++ b/src/services/message-relocator.service.ts
@@ -7,7 +7,10 @@ import {
     TextChannel,
     NewsChannel,
 } from 'discord.js'
-import { isFootballMessage, geminiIsFootball } from './football-detector.service'
+import {
+    isFootballMessage,
+    geminiIsFootball,
+} from './football-detector.service'
 
 const WEBHOOK_NAME = 'shitpost-relocator'
 
@@ -154,7 +157,7 @@ export const maybeRelocateFootballByReaction = async (
             : reactionInput
 
         if (reaction.count < 2) return false
-
+        console.log('Reaccion es mayor a 2')
         const message = reaction.message.partial
             ? await reaction.message.fetch()
             : reaction.message
@@ -164,7 +167,7 @@ export const maybeRelocateFootballByReaction = async (
 
         // Force the LLM — the keyword path already let this through on create.
         if (!(await geminiIsFootball(message.content))) return false
-
+        console.log('mensaje a relocar')
         await relocateMessage(message, targetChannelId)
         return true
     } catch (e) {

--- a/src/services/message-relocator.service.ts
+++ b/src/services/message-relocator.service.ts
@@ -142,8 +142,8 @@ export const maybeRespondFatigueByReaction = async (
     reactionInput: MessageReaction | PartialMessageReaction
 ): Promise<boolean> => {
     const watchedUserIds = getWatchedUserIds()
-    const triggerEmoji = process.env.SHITPOST_TRIGGER_EMOJI
-    const responseEmoji = process.env.JB_FATIGUE_RESPONSE_EMOJI
+    const triggerEmoji = process.env.JB_FATIGUE_EMOJI
+    const responseEmoji = process.env.JB_FATIGUE_EMOJI
     if (!watchedUserIds.length || !triggerEmoji || !responseEmoji) return false
 
     if (

--- a/src/services/message-relocator.service.ts
+++ b/src/services/message-relocator.service.ts
@@ -11,8 +11,18 @@ import {
     isFootballMessage,
     geminiIsFootball,
 } from './football-detector.service'
+import { geminiIsWorkRelated } from './work-detector.service'
 
 const WEBHOOK_NAME = 'shitpost-relocator'
+
+export const getWatchedUserIds = (): string[] =>
+    (process.env.SHITPOST_USER_ID ?? '')
+        .split(',')
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0)
+
+const isWatchedUser = (userId: string, watchedUserIds: string[]): boolean =>
+    watchedUserIds.includes(userId)
 
 type WebhookCapableChannel = TextChannel | NewsChannel
 
@@ -90,10 +100,10 @@ export const relocateMessage = async (
  */
 const isRelocatableMessage = (
     message: Message,
-    watchedUserId: string,
+    watchedUserIds: string[],
     targetChannelId: string
 ): boolean =>
-    message.author.id === watchedUserId &&
+    isWatchedUser(message.author.id, watchedUserIds) &&
     message.channelId !== targetChannelId &&
     message.content.trim().length > 0
 
@@ -108,12 +118,12 @@ const isRelocatableMessage = (
 export const maybeRelocateFootballMessage = async (
     message: Message
 ): Promise<boolean> => {
-    const watchedUserId = process.env.SHITPOST_USER_ID
+    const watchedUserIds = getWatchedUserIds()
     const targetChannelId = process.env.SHITPOST_TARGET_CHANNEL_ID
     if (
-        !watchedUserId ||
+        watchedUserIds.length === 0 ||
         !targetChannelId ||
-        !isRelocatableMessage(message, watchedUserId, targetChannelId)
+        !isRelocatableMessage(message, watchedUserIds, targetChannelId)
     ) {
         return false
     }
@@ -122,6 +132,47 @@ export const maybeRelocateFootballMessage = async (
 
     await relocateMessage(message, targetChannelId)
     return true
+}
+
+/**
+ * If the watched user posts about work/fatigue and someone reacts with the
+ * configured trigger emoji, answer by reacting with the configured fatigue emoji.
+ */
+export const maybeRespondFatigueByReaction = async (
+    reactionInput: MessageReaction | PartialMessageReaction
+): Promise<boolean> => {
+    const watchedUserIds = getWatchedUserIds()
+    const triggerEmoji = process.env.SHITPOST_TRIGGER_EMOJI
+    const responseEmoji = process.env.JB_FATIGUE_RESPONSE_EMOJI
+    if (!watchedUserIds.length || !triggerEmoji || !responseEmoji) return false
+
+    if (
+        reactionInput.emoji.id !== triggerEmoji &&
+        reactionInput.emoji.name !== triggerEmoji
+    ) {
+        return false
+    }
+
+    try {
+        const reaction = reactionInput.partial
+            ? await reactionInput.fetch()
+            : reactionInput
+        const message = reaction.message.partial
+            ? await reaction.message.fetch()
+            : reaction.message
+
+        if (!isWatchedUser(message.author.id, watchedUserIds)) {
+            return false
+        }
+
+        if (!(await geminiIsWorkRelated(message.content))) return false
+
+        await message.react(responseEmoji)
+        return true
+    } catch (e) {
+        console.log('[relocator] fatigue reaction failed:', e)
+        return false
+    }
 }
 
 /**
@@ -136,10 +187,11 @@ export const maybeRelocateFootballMessage = async (
 export const maybeRelocateFootballByReaction = async (
     reactionInput: MessageReaction | PartialMessageReaction
 ): Promise<boolean> => {
-    const watchedUserId = process.env.SHITPOST_USER_ID
+    const watchedUserIds = getWatchedUserIds()
     const targetChannelId = process.env.SHITPOST_TARGET_CHANNEL_ID
     const triggerEmoji = process.env.SHITPOST_TRIGGER_EMOJI // custom emoji ID
-    if (!watchedUserId || !targetChannelId || !triggerEmoji) return false
+    if (!watchedUserIds.length || !targetChannelId || !triggerEmoji)
+        return false
 
     // Cheapest check first, against the partial: the emoji is always populated,
     // so we reject the overwhelming majority of reactions (wrong emoji) before
@@ -162,7 +214,7 @@ export const maybeRelocateFootballByReaction = async (
             ? await reaction.message.fetch()
             : reaction.message
 
-        if (!isRelocatableMessage(message, watchedUserId, targetChannelId))
+        if (!isRelocatableMessage(message, watchedUserIds, targetChannelId))
             return false
 
         // Force the LLM — the keyword path already let this through on create.

--- a/src/services/work-detector.service.ts
+++ b/src/services/work-detector.service.ts
@@ -1,6 +1,6 @@
 import { getClient } from '../components/geminiClient'
 
-const GEMINI_MODEL = process.env.GEMINI_MODEL ?? 'gemini-flash-latest'
+const GEMINI_MODEL = process.env.GEMINI_MODEL ?? ''
 
 const COMBINING_MARKS = /[̀-ͯ]/g
 const normalizeText = (text: string): string =>

--- a/src/services/work-detector.service.ts
+++ b/src/services/work-detector.service.ts
@@ -1,0 +1,31 @@
+import { getClient } from '../components/geminiClient'
+
+const GEMINI_MODEL = process.env.GEMINI_MODEL ?? 'gemini-flash-latest'
+
+/**
+ * Ask Gemini whether a Discord message is about work, getting to work,
+ * or fatigue related to work. Fails open: any error returns false so the bot
+ * does not react unless we are confident enough.
+ */
+export const geminiIsWorkRelated = async (
+    content: string
+): Promise<boolean> => {
+    try {
+        const prompt = `El siguiente mensaje de Discord está escrito en español (puede mezclar inglés). ¿Habla de trabajo, de ponerse a trabajar, de ir a trabajar, de estar trabajando, de jugar videojuegos en horario normal o de cansancio/agotamiento relacionado con el trabajo? Responde ÚNICAMENTE con la palabra SI o NO.\n\nMensaje: """${content}"""`
+
+        const response = await getClient().models.generateContent({
+            model: GEMINI_MODEL,
+            contents: prompt,
+        })
+
+        const answer = (response.text ?? '').trim().toLowerCase()
+        return (
+            answer.startsWith('si') ||
+            answer.startsWith('sí') ||
+            answer.startsWith('yes')
+        )
+    } catch (e) {
+        console.log('[work-detector] Gemini error, failing open:', e)
+        return false
+    }
+}

--- a/src/services/work-detector.service.ts
+++ b/src/services/work-detector.service.ts
@@ -2,6 +2,91 @@ import { getClient } from '../components/geminiClient'
 
 const GEMINI_MODEL = process.env.GEMINI_MODEL ?? 'gemini-flash-latest'
 
+const COMBINING_MARKS = /[̀-ͯ]/g
+const normalizeText = (text: string): string =>
+    text.toLowerCase().normalize('NFD').replace(COMBINING_MARKS, '')
+
+const STRONG_WORK_KEYWORDS = [
+    'trabajo',
+    'trabajar',
+    'trabajando',
+    'trabaja',
+    'trabaje',
+    'trabajes',
+    'trabajamos',
+    'trabajas',
+    'trabajan',
+    'trabajaron',
+    'jornada',
+    'turno',
+    'oficina',
+    'empleo',
+    'empresa',
+    'jefe',
+    'boss',
+    'manager',
+    'reunion',
+    'reunión',
+    'meeting',
+    'deadline',
+    'proyecto',
+    'project',
+    'cliente',
+    'tarea',
+    'tareas',
+    'ticket',
+    'jira',
+    'kanban',
+    'sprint',
+    'horario',
+    'horas',
+]
+
+const STRONG_NON_WORK_KEYWORDS = [
+    'futbol',
+    'gaming',
+    'anime',
+    'pelicula',
+    'serie',
+    'fiesta',
+    'comida',
+    'restaurante',
+    'chafa',
+    'tomar',
+    'controlito',
+    'cs2',
+    'steam',
+]
+
+const AMBIGUOUS_WORK_KEYWORDS = [
+    'cansado',
+    'cansada',
+    'agotado',
+    'agotada',
+    'fatiga',
+    'fatigado',
+    'fatigada',
+    'exhausto',
+    'exhausta',
+    'desmotivado',
+    'desmotivada',
+]
+
+const containsKeyword = (text: string, keywords: string[]): boolean =>
+    keywords.some((keyword) => text.includes(keyword))
+
+export const keywordHasWorkRelated = (
+    content: string
+): 'yes' | 'no' | 'maybe' => {
+    const normalized = normalizeText(content)
+
+    if (containsKeyword(normalized, STRONG_WORK_KEYWORDS)) return 'yes'
+    if (containsKeyword(normalized, STRONG_NON_WORK_KEYWORDS)) return 'no'
+    if (containsKeyword(normalized, AMBIGUOUS_WORK_KEYWORDS)) return 'maybe'
+
+    return 'maybe'
+}
+
 /**
  * Ask Gemini whether a Discord message is about work, getting to work,
  * or fatigue related to work. Fails open: any error returns false so the bot
@@ -10,6 +95,10 @@ const GEMINI_MODEL = process.env.GEMINI_MODEL ?? 'gemini-flash-latest'
 export const geminiIsWorkRelated = async (
     content: string
 ): Promise<boolean> => {
+    const verdict = keywordHasWorkRelated(content)
+    if (verdict === 'yes') return true
+    if (verdict === 'no') return false
+
     try {
         const prompt = `El siguiente mensaje de Discord está escrito en español (puede mezclar inglés). ¿Habla de trabajo, de ponerse a trabajar, de ir a trabajar, de estar trabajando, de jugar videojuegos en horario normal o de cansancio/agotamiento relacionado con el trabajo? Responde ÚNICAMENTE con la palabra SI o NO.\n\nMensaje: """${content}"""`
 

--- a/src/services/work-detector.service.ts
+++ b/src/services/work-detector.service.ts
@@ -101,13 +101,14 @@ export const geminiIsWorkRelated = async (
 
     try {
         const prompt = `El siguiente mensaje de Discord está escrito en español (puede mezclar inglés). ¿Habla de trabajo, de ponerse a trabajar, de ir a trabajar, de estar trabajando, de jugar videojuegos en horario normal o de cansancio/agotamiento relacionado con el trabajo? Responde ÚNICAMENTE con la palabra SI o NO.\n\nMensaje: """${content}"""`
-
+        console.log(`geminiIsWorkRelated prompt: ${prompt}`)
         const response = await getClient().models.generateContent({
             model: GEMINI_MODEL,
             contents: prompt,
         })
 
         const answer = (response.text ?? '').trim().toLowerCase()
+        console.log(`geminiIsWorkRelated answer ${answer}`)
         return (
             answer.startsWith('si') ||
             answer.startsWith('sí') ||


### PR DESCRIPTION
This PR adds support for reacting to work-related messages from watched users using a Gemini-based detector instead of regex matching. It also allows SHITPOST_USER_ID to contain multiple user IDs separated by commas, and triggers a configurable emoji response when the configured reaction emoji is used.

New envs

- JB_FATIGUE_EMOJI