### PR TITLE
Split watched-user env var: FATIGUE_USER_ID for work detector

### DIFF
--- a/src/services/message-relocator.service.ts
+++ b/src/services/message-relocator.service.ts
@@ -15,11 +15,19 @@ import { geminiIsWorkRelated } from './work-detector.service'
 
 const WEBHOOK_NAME = 'shitpost-relocator'
 
-export const getWatchedUserIds = (): string[] =>
-    (process.env.SHITPOST_USER_ID ?? '')
+const parseUserIds = (raw: string | undefined): string[] =>
+    (raw ?? '')
         .split(',')
         .map((id) => id.trim())
         .filter((id) => id.length > 0)
+
+// Watched user for the football relocator.
+export const getWatchedUserIds = (): string[] =>
+    parseUserIds(process.env.SHITPOST_USER_ID)
+
+// Watched user for the work/fatigue detector.
+export const getFatigueUserIds = (): string[] =>
+    parseUserIds(process.env.FATIGUE_USER_ID)
 
 const isWatchedUser = (userId: string, watchedUserIds: string[]): boolean =>
     watchedUserIds.includes(userId)
@@ -141,7 +149,7 @@ export const maybeRelocateFootballMessage = async (
 export const maybeRespondFatigueByReaction = async (
     reactionInput: MessageReaction | PartialMessageReaction
 ): Promise<boolean> => {
-    const watchedUserIds = getWatchedUserIds()
+    const watchedUserIds = getFatigueUserIds()
     const triggerEmoji = process.env.JB_FATIGUE_EMOJI
     const responseEmoji = process.env.JB_FATIGUE_EMOJI
     if (!watchedUserIds.length || !triggerEmoji || !responseEmoji) return false


### PR DESCRIPTION
## What

The work/fatigue detector and the football relocator both watched a user via the same `SHITPOST_USER_ID` env var, but they target two different users. This splits them so each detector has its own watched user.

## Changes

- Extracted a `parseUserIds()` helper (the split/trim/filter logic).
- `getWatchedUserIds()` still reads `SHITPOST_USER_ID` — football relocator (`maybeRelocateFootballMessage`, `maybeRelocateFootballByReaction`).
- Added `getFatigueUserIds()` reading the new `FATIGUE_USER_ID` — work/fatigue detector (`maybeRespondFatigueByReaction`).

## Deployment note

Set the new `FATIGUE_USER_ID` env var to the work-detector user, and trim that ID out of `SHITPOST_USER_ID` so it only holds the football user. Remember to update `.env.example` / `.env` and the Render env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)