### PR TITLE
Fix duplicate 'Si Justin' replies on multiple reactions

### DIFF
--- a/src/services/message-relocator.service.ts
+++ b/src/services/message-relocator.service.ts
@@ -165,6 +165,10 @@ export const maybeRespondFatigueByReaction = async (
             return false
         }
 
+        // Only the first reactor triggers a reply; later reactors on the same
+        // message see count > 1 and are ignored, so we answer at most once.
+        if (reaction.count > 1) return false
+
         if (!(await geminiIsWorkRelated(message.content))) return false
 
         await message.reply(`Si Justin <:custom_name:${responseEmoji}>`)

--- a/src/services/message-relocator.service.ts
+++ b/src/services/message-relocator.service.ts
@@ -165,9 +165,9 @@ export const maybeRespondFatigueByReaction = async (
             return false
         }
 
-        // Only the first reactor triggers a reply; later reactors on the same
-        // message see count > 1 and are ignored, so we answer at most once.
-        if (reaction.count > 1) return false
+        // Only the first 2 reactions triggers; later reactors on the same
+        // message see count different than 2 and are ignored, so we answer at most once.
+        if (reaction.count !== 2) return false
 
         if (!(await geminiIsWorkRelated(message.content))) return false
 


### PR DESCRIPTION
## Problem

The fatigue reaction handler (\`maybeRespondFatigueByReaction\`) runs on **every** \`messageReactionAdd\` event with no per-message guard. When several users react to the same watched message with the trigger emoji, the bot replies \"Si Justin\" once per reactor — producing the spam seen in the wild (a message with a reaction count of 4 got replies at 3:22, 3:23, and 3:24 as different people piled on).

## Why football didn't have this bug

The football reaction handler consumes its own trigger: \`relocateMessage\` deletes the original message, so no further reactions can fire on it. The fatigue path only replies and leaves the message in place, so every new reactor re-triggers it.

## Fix

Only reply when the trigger emoji is added for the **first** time (\`reaction.count === 1\`), so we answer at most once per message. One line, no module state, no memory growth, and survives restarts (count stays > 1 after the first reaction).

The only remaining gap is two reactions arriving in the same instant — a rare race whose worst case is one extra reply, acceptable for this feature.